### PR TITLE
corrected code

### DIFF
--- a/Greedy/FractionalKnapsack.cpp
+++ b/Greedy/FractionalKnapsack.cpp
@@ -52,7 +52,7 @@ long long go(vector<vector<long long>> worker, long long area){
 		// cout << "Worker: "<<current_worker << '\n';
 		// cout << "Timegap: "<<time_gap << '\n';
 		
-		area_done += time_gap*(worker.at(current_worker)[1]);
+		area_done += time_gap*(worker.at(current_worker)[2]);
 
 		// cout <<"Cost: "<<cost<< '\n';
 		// cout <<"Area done: "<<area_done<< '\n'<<endl;


### PR DESCRIPTION
`worker.at(current_worker)[2]`
index 1 might be giving you the correct answer but in the vector with size 3, cost is stored at the second index, not area per unit.
Please look carefully at the proposed changes.
This code will give the correct answer.